### PR TITLE
chore: lang version to 11

### DIFF
--- a/app/src/main/java/org/example/app/AccountDemo.java
+++ b/app/src/main/java/org/example/app/AccountDemo.java
@@ -26,7 +26,7 @@ public class AccountDemo {
     try (var client = Client.newBuilder(config).build()) {
 
       var basins = client.listBasins(ListBasinsRequest.newBuilder().build()).get();
-      basins.elems().forEach(basin -> logger.info("basin={}", basin));
+      basins.elems.forEach(basin -> logger.info("basin={}", basin));
 
       var newBasin =
           client

--- a/app/src/main/java/org/example/app/BasinDemo.java
+++ b/app/src/main/java/org/example/app/BasinDemo.java
@@ -22,12 +22,10 @@ public class BasinDemo {
     try (final var basinClient =
         BasinClient.newBuilder(config, System.getenv("S2_BASIN")).build()) {
       final var streams = basinClient.listStreams(ListStreamsRequest.newBuilder().build()).get();
-      streams
-          .elems()
-          .forEach(
-              stream -> {
-                logger.info("stream={}", stream);
-              });
+      streams.elems.forEach(
+          stream -> {
+            logger.info("stream={}", stream);
+          });
 
       var newStream =
           basinClient

--- a/app/src/main/java/org/example/app/ManagedReadSessionDemo.java
+++ b/app/src/main/java/org/example/app/ManagedReadSessionDemo.java
@@ -33,9 +33,13 @@ public class ManagedReadSessionDemo {
       throw new IllegalStateException("S2_STREAM not set");
     }
 
-    var config = Config.newBuilder(authToken).withEndpoints(Endpoints.fromEnvironment()).build();
+    var config =
+        Config.newBuilder(authToken)
+            .withEndpoints(Endpoints.fromEnvironment())
+            .withCompression(true)
+            .build();
 
-    try (final var executor = new ScheduledThreadPoolExecutor(1);
+    try (final var executor = new ScheduledThreadPoolExecutor(12);
         final var channel = ManagedChannelFactory.forBasinOrStreamService(config, basinName)) {
 
       final var streamClient =
@@ -47,7 +51,7 @@ public class ManagedReadSessionDemo {
       try (final var managedSession =
           streamClient.managedReadSession(
               ReadSessionRequest.newBuilder().withReadLimit(ReadLimit.count(100_000)).build(),
-              1024 * 1024 * 1024)) {
+              1024 * 1024 * 1024 * 5)) {
 
         AtomicLong receivedBytes = new AtomicLong();
         while (!managedSession.isClosed()) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.13-SNAPSHOT
+version=0.0.13

--- a/s2-internal/build.gradle.kts
+++ b/s2-internal/build.gradle.kts
@@ -54,7 +54,7 @@ protobuf {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(11))
     }
     withJavadocJar()
     withSourcesJar()

--- a/s2-sdk/build.gradle.kts
+++ b/s2-sdk/build.gradle.kts
@@ -45,7 +45,7 @@ tasks.test {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(11))
     }
     withJavadocJar()
     withSourcesJar()

--- a/s2-sdk/src/main/java/s2/client/BaseClient.java
+++ b/s2-sdk/src/main/java/s2/client/BaseClient.java
@@ -52,10 +52,14 @@ public abstract class BaseClient implements AutoCloseable {
   }
 
   static boolean retryableStatus(Status status) {
-    return switch (status.getCode()) {
-      case UNKNOWN, DEADLINE_EXCEEDED, UNAVAILABLE -> true;
-      default -> false;
-    };
+    switch (status.getCode()) {
+      case UNKNOWN:
+      case DEADLINE_EXCEEDED:
+      case UNAVAILABLE:
+        return true;
+      default:
+        return false;
+    }
   }
 
   public void close() {

--- a/s2-sdk/src/main/java/s2/client/BasinClient.java
+++ b/s2-sdk/src/main/java/s2/client/BasinClient.java
@@ -8,6 +8,7 @@ import io.grpc.stub.MetadataUtils;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
 import s2.auth.BearerTokenCallCredentials;
 import s2.channel.BasinCompatibleChannel;
 import s2.channel.ManagedChannelFactory;
@@ -66,7 +67,9 @@ public class BasinClient extends BaseClient {
                 resp ->
                     new Paginated<>(
                         resp.getHasMore(),
-                        resp.getStreamsList().stream().map(StreamInfo::fromProto).toList()),
+                        resp.getStreamsList().stream()
+                            .map(StreamInfo::fromProto)
+                            .collect(Collectors.toList())),
                 executor));
   }
 

--- a/s2-sdk/src/main/java/s2/client/Client.java
+++ b/s2-sdk/src/main/java/s2/client/Client.java
@@ -8,6 +8,7 @@ import io.grpc.stub.MetadataUtils;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import s2.auth.BearerTokenCallCredentials;
@@ -61,7 +62,9 @@ public class Client extends BaseClient {
                 resp ->
                     new Paginated<>(
                         resp.getHasMore(),
-                        resp.getBasinsList().stream().map(BasinInfo::fromProto).toList()),
+                        resp.getBasinsList().stream()
+                            .map(BasinInfo::fromProto)
+                            .collect(Collectors.toList())),
                 executor));
   }
 

--- a/s2-sdk/src/main/java/s2/client/ReadSession.java
+++ b/s2-sdk/src/main/java/s2/client/ReadSession.java
@@ -84,10 +84,11 @@ public class ReadSession implements AutoCloseable {
         readSessionInner(
             request.update(nextStartSeqNum.get(), consumedRecords.get(), consumedBytes.get()),
             resp -> {
-              if (resp instanceof Batch batch) {
+              if (resp instanceof Batch) {
+                final Batch batch = (Batch) resp;
                 var lastRecordIdx = batch.lastSeqNum();
                 lastRecordIdx.ifPresent(v -> nextStartSeqNum.set(v + 1));
-                consumedRecords.addAndGet(batch.sequencedRecordBatch().records().size());
+                consumedRecords.addAndGet(batch.sequencedRecordBatch.records.size());
                 consumedBytes.addAndGet(batch.meteredBytes());
               }
               this.remainingAttempts.set(client.config.maxRetries);

--- a/s2-sdk/src/main/java/s2/client/StreamClient.java
+++ b/s2-sdk/src/main/java/s2/client/StreamClient.java
@@ -160,7 +160,7 @@ public class StreamClient extends BasinClient {
    * Append a batch of records to a stream, using the unary append RPC.
    *
    * <p>Note that the choice of {@link Config#appendRetryPolicy} is important. Since appends are not
-   * idempotent by default, retries <i>could</i> cause duplicates in a stream. If you use-case
+   * idempotent by default, retries <i>could</i> cause duplicates in a stream. If your use-case
    * cannot tolerate the potential of duplicate records, make sure to select {@link
    * AppendRetryPolicy#NO_SIDE_EFFECTS}.
    *

--- a/s2-sdk/src/main/java/s2/client/StreamClient.java
+++ b/s2-sdk/src/main/java/s2/client/StreamClient.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import s2.auth.BearerTokenCallCredentials;
 import s2.channel.BasinCompatibleChannel;
 import s2.channel.ManagedChannelFactory;
+import s2.config.AppendRetryPolicy;
 import s2.config.Config;
 import s2.types.AppendInput;
 import s2.types.AppendOutput;
@@ -21,6 +22,7 @@ import s2.types.ReadOutput;
 import s2.types.ReadRequest;
 import s2.types.ReadSessionRequest;
 import s2.v1alpha.AppendRequest;
+import s2.v1alpha.AppendResponse;
 import s2.v1alpha.AppendSessionRequest;
 import s2.v1alpha.AppendSessionResponse;
 import s2.v1alpha.CheckTailRequest;
@@ -97,7 +99,7 @@ public class StreamClient extends BasinClient {
   /**
    * Retrieve a batch of records from a stream, using the unary read RPC.
    *
-   * @see s2.client.StreamClient#readSession
+   * @see StreamClient#readSession
    * @param request the request
    * @return future of the read result
    */
@@ -115,14 +117,13 @@ public class StreamClient extends BasinClient {
    * Retrieve batches of records from a stream continuously.
    *
    * <p>This entryway into a read session does internally perform retries (if configured via {@link
-   * s2.config.Config#maxRetries}). It does not handle any form of backpressure or flow control
-   * directly.
+   * Config#maxRetries}). It does not handle any form of backpressure or flow control directly.
    *
    * <p>The stream is interacted with via callbacks, which delegate to an underlying GRPC <a
    * href="https://grpc.github.io/grpc-java/javadoc/io/grpc/stub/StreamObserver.html">StreamObserver</a>
    * class.
    *
-   * @see s2.client.StreamClient#managedReadSession
+   * @see StreamClient#managedReadSession
    * @param request the request
    * @param onResponse function to run, sequentially, on each successful message
    * @param onError function to run on an error
@@ -136,15 +137,15 @@ public class StreamClient extends BasinClient {
   /**
    * Retrieve batches of records from a stream continuously, using a buffered queue-backed iterator.
    *
-   * <p>This entryway into a read session, similar to {@link s2.client.StreamClient#readSession},
-   * will retry internally if configured.
+   * <p>This entryway into a read session, similar to {@link StreamClient#readSession}, will retry
+   * internally if configured.
    *
    * <p>The GRPC streaming response will be buffered, based on the `maxBufferedBytes` param,
    * preventing situations where the result of a read accumulate faster than a user can handle.
    *
    * <p>Results are interacted with via an interator-like API, rather than via callbacks.
    *
-   * @see s2.client.StreamClient#readSession
+   * @see StreamClient#readSession
    * @param request the request
    * @param maxBufferedBytes the max allowed amount of read response metered bytes to keep in the
    *     buffer
@@ -158,35 +159,40 @@ public class StreamClient extends BasinClient {
   /**
    * Append a batch of records to a stream, using the unary append RPC.
    *
-   * <p>Note that the choice of {@link s2.config.Config#appendRetryPolicy} is important. Since
-   * appends are not idempotent by default, retries <i>could</i> cause duplicates in a stream. If
-   * you use-case cannot tolerate the potential of duplicate records, make sure to select {@link
-   * s2.config.AppendRetryPolicy#NO_SIDE_EFFECTS}.
+   * <p>Note that the choice of {@link Config#appendRetryPolicy} is important. Since appends are not
+   * idempotent by default, retries <i>could</i> cause duplicates in a stream. If you use-case
+   * cannot tolerate the potential of duplicate records, make sure to select {@link
+   * AppendRetryPolicy#NO_SIDE_EFFECTS}.
    *
-   * @see s2.config.Config#appendRetryPolicy
-   * @see s2.config.AppendRetryPolicy
+   * @see Config#appendRetryPolicy
+   * @see AppendRetryPolicy
    * @param request the request
    * @return future of the append response
    */
   public ListenableFuture<AppendOutput> append(AppendInput request) {
+    ListenableFuture<AppendResponse> future;
+    switch (config.appendRetryPolicy) {
+      case ALL:
+        future =
+            withStaticRetries(
+                config.maxRetries,
+                () ->
+                    this.futureStub.append(
+                        AppendRequest.newBuilder().setInput(request.toProto(streamName)).build()));
+        break;
+      case NO_SIDE_EFFECTS:
+        future =
+            this.futureStub.append(
+                AppendRequest.newBuilder().setInput(request.toProto(streamName)).build());
+        break;
+      default:
+        throw new UnsupportedOperationException(
+            "Unsupported append retry policy: " + config.appendRetryPolicy);
+    }
     return withTimeout(
         () ->
             Futures.transform(
-                switch (config.appendRetryPolicy) {
-                  case ALL ->
-                      withStaticRetries(
-                          config.maxRetries,
-                          () ->
-                              this.futureStub.append(
-                                  AppendRequest.newBuilder()
-                                      .setInput(request.toProto(streamName))
-                                      .build()));
-                  case NO_SIDE_EFFECTS ->
-                      this.futureStub.append(
-                          AppendRequest.newBuilder().setInput(request.toProto(streamName)).build());
-                },
-                response -> AppendOutput.fromProto(response.getOutput()),
-                executor));
+                future, response -> AppendOutput.fromProto(response.getOutput()), executor));
   }
 
   /**
@@ -243,13 +249,13 @@ public class StreamClient extends BasinClient {
    * <p>Unlike with {@link StreamClient#appendSession}, this session will attempt to retry
    * intermittent failures if so elected.
    *
-   * <p>Note that the choice of {@link s2.config.Config#appendRetryPolicy} is important. Since
-   * appends are not idempotent by default, retries <i>could</i> cause duplicates in a stream. If
-   * you use-case cannot tolerate the potential of duplicate records, make sure to select {@link
-   * s2.config.AppendRetryPolicy#NO_SIDE_EFFECTS}.
+   * <p>Note that the choice of {@link Config#appendRetryPolicy} is important. Since appends are not
+   * idempotent by default, retries <i>could</i> cause duplicates in a stream. If you use-case
+   * cannot tolerate the potential of duplicate records, make sure to select {@link
+   * AppendRetryPolicy#NO_SIDE_EFFECTS}.
    *
-   * @see s2.config.Config#appendRetryPolicy
-   * @see s2.config.AppendRetryPolicy
+   * @see Config#appendRetryPolicy
+   * @see AppendRetryPolicy
    * @return the managed append session
    */
   public ManagedAppendSession managedAppendSession() {
@@ -293,6 +299,16 @@ public class StreamClient extends BasinClient {
     }
   }
 
-  public record AppendSessionRequestStream(
-      Consumer<AppendInput> onNext, Consumer<Throwable> onError, Runnable onComplete) {}
+  public static class AppendSessionRequestStream {
+    final Consumer<AppendInput> onNext;
+    final Consumer<Throwable> onError;
+    final Runnable onComplete;
+
+    AppendSessionRequestStream(
+        Consumer<AppendInput> onNext, Consumer<Throwable> onError, Runnable onComplete) {
+      this.onNext = onNext;
+      this.onError = onError;
+      this.onComplete = onComplete;
+    }
+  }
 }

--- a/s2-sdk/src/main/java/s2/config/BasinEndpoint.java
+++ b/s2-sdk/src/main/java/s2/config/BasinEndpoint.java
@@ -2,7 +2,7 @@ package s2.config;
 
 import java.util.Objects;
 
-public abstract sealed class BasinEndpoint permits ParentZone, Direct {
+public abstract class BasinEndpoint {
   public final Address address;
 
   BasinEndpoint(Address address) {

--- a/s2-sdk/src/main/java/s2/config/Endpoints.java
+++ b/s2-sdk/src/main/java/s2/config/Endpoints.java
@@ -48,7 +48,8 @@ public final class Endpoints {
   }
 
   public boolean singleEndpoint() {
-    if (this.basin instanceof Direct direct) {
+    if (this.basin instanceof Direct) {
+      final Direct direct = (Direct) this.basin;
       return this.account.equals(direct.address);
     } else if (this.basin instanceof ParentZone) {
       return false;

--- a/s2-sdk/src/main/java/s2/types/AppendOutput.java
+++ b/s2-sdk/src/main/java/s2/types/AppendOutput.java
@@ -1,8 +1,25 @@
 package s2.types;
 
-public record AppendOutput(long startSeqNum, long endSeqNum, long nextSeqNum) {
+public class AppendOutput {
+  public final long startSeqNum;
+  public final long endSeqNum;
+  public final long nextSeqNum;
+
+  AppendOutput(long startSeqNum, long endSeqNum, long nextSeqNum) {
+    this.startSeqNum = startSeqNum;
+    this.endSeqNum = endSeqNum;
+    this.nextSeqNum = nextSeqNum;
+  }
+
   public static AppendOutput fromProto(s2.v1alpha.AppendOutput appendOutput) {
     return new AppendOutput(
         appendOutput.getStartSeqNum(), appendOutput.getEndSeqNum(), appendOutput.getNextSeqNum());
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "AppendOutput[startSeqNum=%s, endSeqNum=%s, nextSeqNum=%s]",
+        startSeqNum, endSeqNum, nextSeqNum);
   }
 }

--- a/s2-sdk/src/main/java/s2/types/AppendRecord.java
+++ b/s2-sdk/src/main/java/s2/types/AppendRecord.java
@@ -24,7 +24,7 @@ public class AppendRecord implements MeteredBytes, Serializable {
   public long meteredBytes() {
     return 8
         + (2L * this.headers.size())
-        + this.headers.stream().map(h -> h.name().size() + h.value().size()).reduce(0, Integer::sum)
+        + this.headers.stream().map(h -> h.name.size() + h.value.size()).reduce(0, Integer::sum)
         + this.body.size();
   }
 

--- a/s2-sdk/src/main/java/s2/types/BasinConfig.java
+++ b/s2-sdk/src/main/java/s2/types/BasinConfig.java
@@ -1,6 +1,12 @@
 package s2.types;
 
-public record BasinConfig(StreamConfig defaultStreamConfig) {
+public class BasinConfig {
+  public final StreamConfig defaultStreamConfig;
+
+  public BasinConfig(StreamConfig defaultStreamConfig) {
+    this.defaultStreamConfig = defaultStreamConfig;
+  }
+
   public s2.v1alpha.BasinConfig toProto() {
     return s2.v1alpha.BasinConfig.newBuilder()
         .setDefaultStreamConfig(defaultStreamConfig.toProto())

--- a/s2-sdk/src/main/java/s2/types/BasinInfo.java
+++ b/s2-sdk/src/main/java/s2/types/BasinInfo.java
@@ -1,15 +1,41 @@
 package s2.types;
 
-public record BasinInfo(String name, String scope, String cell, BasinState state) {
+public class BasinInfo {
+  public final String name;
+  public final String scope;
+  public final String cell;
+  public final BasinState basinState;
+
+  BasinInfo(String name, String scope, String cell, BasinState basinState) {
+    this.name = name;
+    this.scope = scope;
+    this.cell = cell;
+    this.basinState = basinState;
+  }
+
   public static BasinInfo fromProto(s2.v1alpha.BasinInfo basinInfo) {
-    var state =
-        switch (basinInfo.getState()) {
-          case BASIN_STATE_UNSPECIFIED -> BasinState.UNSPECIFIED;
-          case BASIN_STATE_ACTIVE -> BasinState.ACTIVE;
-          case BASIN_STATE_CREATING -> BasinState.CREATING;
-          case BASIN_STATE_DELETING -> BasinState.DELETING;
-          default -> BasinState.UNKNOWN;
-        };
+    BasinState state;
+    switch (basinInfo.getState()) {
+      case BASIN_STATE_UNSPECIFIED:
+        state = BasinState.UNSPECIFIED;
+        break;
+      case BASIN_STATE_ACTIVE:
+        state = BasinState.ACTIVE;
+        break;
+      case BASIN_STATE_CREATING:
+        state = BasinState.CREATING;
+        break;
+      case BASIN_STATE_DELETING:
+        state = BasinState.DELETING;
+        break;
+      default:
+        state = BasinState.UNKNOWN;
+        break;
+    }
+
     return new BasinInfo(basinInfo.getName(), basinInfo.getScope(), basinInfo.getCell(), state);
   }
 }
+
+// public record BasinInfo(String name, String scope, String cell, BasinState state) {
+// }

--- a/s2-sdk/src/main/java/s2/types/BasinInfo.java
+++ b/s2-sdk/src/main/java/s2/types/BasinInfo.java
@@ -36,6 +36,3 @@ public class BasinInfo {
     return new BasinInfo(basinInfo.getName(), basinInfo.getScope(), basinInfo.getCell(), state);
   }
 }
-
-// public record BasinInfo(String name, String scope, String cell, BasinState state) {
-// }

--- a/s2-sdk/src/main/java/s2/types/Batch.java
+++ b/s2-sdk/src/main/java/s2/types/Batch.java
@@ -2,19 +2,22 @@ package s2.types;
 
 import java.util.Optional;
 
-public record Batch(SequencedRecordBatch sequencedRecordBatch) implements ReadOutput, MeteredBytes {
+public final class Batch implements ReadOutput, MeteredBytes {
+
+  public final SequencedRecordBatch sequencedRecordBatch;
+
+  Batch(SequencedRecordBatch sequencedRecordBatch) {
+    this.sequencedRecordBatch = sequencedRecordBatch;
+  }
 
   public Optional<Long> firstSeqNum() {
-    return this.sequencedRecordBatch.records().stream().findFirst().map(SequencedRecord::seqNum);
+    return this.sequencedRecordBatch.records.stream().findFirst().map(sr -> sr.seqNum);
   }
 
   public Optional<Long> lastSeqNum() {
-    if (!this.sequencedRecordBatch.records().isEmpty()) {
+    if (!this.sequencedRecordBatch.records.isEmpty()) {
       return Optional.of(
-          this.sequencedRecordBatch
-              .records()
-              .get(sequencedRecordBatch.records().size() - 1)
-              .seqNum());
+          this.sequencedRecordBatch.records.get(sequencedRecordBatch.records.size() - 1).seqNum);
     } else {
       return Optional.empty();
     }

--- a/s2-sdk/src/main/java/s2/types/CreateBasinRequest.java
+++ b/s2-sdk/src/main/java/s2/types/CreateBasinRequest.java
@@ -26,7 +26,7 @@ public class CreateBasinRequest {
     return builder.build();
   }
 
-  abstract static sealed class BasinAssignment permits Scope, Cell {
+  abstract static class BasinAssignment {
     public final String value;
 
     BasinAssignment(String value) {

--- a/s2-sdk/src/main/java/s2/types/FirstSeqNum.java
+++ b/s2-sdk/src/main/java/s2/types/FirstSeqNum.java
@@ -1,3 +1,10 @@
 package s2.types;
 
-public record FirstSeqNum(long value) implements ReadOutput {}
+public final class FirstSeqNum implements ReadOutput {
+
+  public final long value;
+
+  public FirstSeqNum(long value) {
+    this.value = value;
+  }
+}

--- a/s2-sdk/src/main/java/s2/types/Header.java
+++ b/s2-sdk/src/main/java/s2/types/Header.java
@@ -2,13 +2,20 @@ package s2.types;
 
 import com.google.protobuf.ByteString;
 
-public record Header(ByteString name, ByteString value) {
+public class Header {
+  public final ByteString name;
+  public final ByteString value;
 
-  public static Header fromProto(s2.v1alpha.Header header) {
-    return new Header(header.getName(), header.getValue());
+  public Header(ByteString name, ByteString value) {
+    this.name = name;
+    this.value = value;
   }
 
   public s2.v1alpha.Header toProto() {
     return s2.v1alpha.Header.newBuilder().setName(name).setValue(value).build();
+  }
+
+  public static Header fromProto(s2.v1alpha.Header protoHeader) {
+    return new Header(protoHeader.getName(), protoHeader.getValue());
   }
 }

--- a/s2-sdk/src/main/java/s2/types/NextSeqNum.java
+++ b/s2-sdk/src/main/java/s2/types/NextSeqNum.java
@@ -1,3 +1,9 @@
 package s2.types;
 
-public record NextSeqNum(long value) implements ReadOutput {}
+public final class NextSeqNum implements ReadOutput {
+  public final long value;
+
+  public NextSeqNum(long value) {
+    this.value = value;
+  }
+}

--- a/s2-sdk/src/main/java/s2/types/Paginated.java
+++ b/s2-sdk/src/main/java/s2/types/Paginated.java
@@ -2,4 +2,12 @@ package s2.types;
 
 import java.util.List;
 
-public record Paginated<T>(boolean hasMore, List<T> elems) {}
+public class Paginated<T> {
+  public final boolean hasMore;
+  public final List<T> elems;
+
+  public Paginated(boolean hasMore, List<T> elems) {
+    this.hasMore = hasMore;
+    this.elems = elems;
+  }
+}

--- a/s2-sdk/src/main/java/s2/types/ReadOutput.java
+++ b/s2-sdk/src/main/java/s2/types/ReadOutput.java
@@ -1,18 +1,15 @@
 package s2.types;
 
-public sealed interface ReadOutput permits Batch, FirstSeqNum, NextSeqNum {
+public interface ReadOutput {
   static ReadOutput fromProto(s2.v1alpha.ReadOutput readOutput) {
     switch (readOutput.getOutputCase()) {
-      case BATCH -> {
+      case BATCH:
         return new Batch(SequencedRecordBatch.fromProto(readOutput.getBatch()));
-      }
-      case FIRST_SEQ_NUM -> {
+      case FIRST_SEQ_NUM:
         return new FirstSeqNum(readOutput.getFirstSeqNum());
-      }
-      case NEXT_SEQ_NUM -> {
+      case NEXT_SEQ_NUM:
         return new NextSeqNum(readOutput.getNextSeqNum());
-      }
     }
-    throw new IllegalStateException("Unrecognized readOutput case: " + readOutput.getOutputCase());
+    throw new IllegalStateException("Unrecognized readOutput case: " + readOutput);
   }
 }

--- a/s2-sdk/src/main/java/s2/types/RetentionPolicy.java
+++ b/s2-sdk/src/main/java/s2/types/RetentionPolicy.java
@@ -1,3 +1,3 @@
 package s2.types;
 
-public abstract sealed class RetentionPolicy permits Age {}
+public abstract class RetentionPolicy {}

--- a/s2-sdk/src/main/java/s2/types/SequencedRecord.java
+++ b/s2-sdk/src/main/java/s2/types/SequencedRecord.java
@@ -2,21 +2,33 @@ package s2.types;
 
 import com.google.protobuf.ByteString;
 import java.util.List;
+import java.util.stream.Collectors;
 
-public record SequencedRecord(Long seqNum, List<Header> headers, ByteString body)
-    implements MeteredBytes {
-  public static SequencedRecord fromProto(s2.v1alpha.SequencedRecord sequencedRecord) {
-    return new SequencedRecord(
-        sequencedRecord.getSeqNum(),
-        sequencedRecord.getHeadersList().stream().map(Header::fromProto).toList(),
-        sequencedRecord.getBody());
+public class SequencedRecord implements MeteredBytes {
+  public final long seqNum;
+  public final List<Header> headers;
+  public final ByteString body;
+
+  SequencedRecord(long seqNum, List<Header> headers, ByteString body) {
+    this.seqNum = seqNum;
+    this.headers = headers;
+    this.body = body;
   }
 
   @Override
   public long meteredBytes() {
     return 8
         + (2L * this.headers.size())
-        + this.headers.stream().map(h -> h.name().size() + h.value().size()).reduce(0, Integer::sum)
+        + this.headers.stream().map(h -> h.name.size() + h.value.size()).reduce(0, Integer::sum)
         + this.body.size();
+  }
+
+  public static SequencedRecord fromProto(s2.v1alpha.SequencedRecord sequencedRecord) {
+    return new SequencedRecord(
+        sequencedRecord.getSeqNum(),
+        sequencedRecord.getHeadersList().stream()
+            .map(Header::fromProto)
+            .collect(Collectors.toList()),
+        sequencedRecord.getBody());
   }
 }

--- a/s2-sdk/src/main/java/s2/types/SequencedRecordBatch.java
+++ b/s2-sdk/src/main/java/s2/types/SequencedRecordBatch.java
@@ -1,12 +1,20 @@
 package s2.types;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
-public record SequencedRecordBatch(List<SequencedRecord> records) implements MeteredBytes {
+public class SequencedRecordBatch implements MeteredBytes {
+  public final List<SequencedRecord> records;
+
+  SequencedRecordBatch(List<SequencedRecord> records) {
+    this.records = records;
+  }
 
   public static SequencedRecordBatch fromProto(s2.v1alpha.SequencedRecordBatch batch) {
     return new SequencedRecordBatch(
-        batch.getRecordsList().stream().map(SequencedRecord::fromProto).toList());
+        batch.getRecordsList().stream()
+            .map(SequencedRecord::fromProto)
+            .collect(Collectors.toList()));
   }
 
   @Override

--- a/s2-sdk/src/main/java/s2/types/StreamConfig.java
+++ b/s2-sdk/src/main/java/s2/types/StreamConfig.java
@@ -2,6 +2,7 @@ package s2.types;
 
 import java.time.Duration;
 import java.util.Optional;
+import s2.v1alpha.StreamConfig.RetentionPolicyCase;
 
 public class StreamConfig {
 
@@ -14,18 +15,27 @@ public class StreamConfig {
   }
 
   public static StreamConfig fromProto(s2.v1alpha.StreamConfig proto) {
-    var storageClass =
-        switch (proto.getStorageClass()) {
-          case STORAGE_CLASS_UNSPECIFIED -> StorageClass.UNSPECIFIED;
-          case STORAGE_CLASS_STANDARD -> StorageClass.STANDARD;
-          case STORAGE_CLASS_EXPRESS -> StorageClass.EXPRESS;
-          default -> StorageClass.UNKNOWN;
-        };
-    Optional<RetentionPolicy> retentionPolicy =
-        switch (proto.getRetentionPolicyCase()) {
-          case AGE -> Optional.of(new Age(Duration.ofSeconds(proto.getAge())));
-          case RETENTIONPOLICY_NOT_SET -> Optional.empty();
-        };
+    StorageClass storageClass;
+    switch (proto.getStorageClass()) {
+      case STORAGE_CLASS_UNSPECIFIED:
+        storageClass = StorageClass.UNSPECIFIED;
+        break;
+      case STORAGE_CLASS_STANDARD:
+        storageClass = StorageClass.STANDARD;
+        break;
+      case STORAGE_CLASS_EXPRESS:
+        storageClass = StorageClass.EXPRESS;
+        break;
+      default:
+        storageClass = StorageClass.UNKNOWN;
+        break;
+    }
+
+    Optional<RetentionPolicy> retentionPolicy = Optional.empty();
+
+    if (proto.getRetentionPolicyCase() == RetentionPolicyCase.AGE) {
+      retentionPolicy = Optional.of(new Age(Duration.ofSeconds(proto.getAge())));
+    }
     return new StreamConfig(storageClass, retentionPolicy);
   }
 

--- a/s2-sdk/src/main/java/s2/types/StreamInfo.java
+++ b/s2-sdk/src/main/java/s2/types/StreamInfo.java
@@ -3,7 +3,17 @@ package s2.types;
 import java.time.Instant;
 import java.util.Optional;
 
-public record StreamInfo(String name, Instant createdAt, Optional<Instant> deletedAt) {
+public class StreamInfo {
+  public final String name;
+  public final Instant createdAt;
+  public final Optional<Instant> deletedAt;
+
+  private StreamInfo(String name, Instant createdAt, Optional<Instant> deletedAt) {
+    this.name = name;
+    this.createdAt = createdAt;
+    this.deletedAt = deletedAt;
+  }
+
   public static StreamInfo fromProto(s2.v1alpha.StreamInfo streamInfo) {
     var createdAt = Instant.ofEpochSecond(streamInfo.getCreatedAt());
     Optional<Instant> deletedAt =

--- a/s2-sdk/src/test/java/s2/client/ReadSessionTest.java
+++ b/s2-sdk/src/test/java/s2/client/ReadSessionTest.java
@@ -9,6 +9,7 @@ import io.grpc.inprocess.InProcessServerBuilder;
 import java.util.ArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -79,10 +80,10 @@ public class ReadSessionTest {
     System.out.println(received);
     var flattenedRecords =
         received.stream()
-            .flatMap(o -> ((Batch) o).sequencedRecordBatch().records().stream())
-            .toList();
+            .flatMap(o -> ((Batch) o).sequencedRecordBatch.records.stream())
+            .collect(Collectors.toList());
     assertThat(flattenedRecords.size()).isEqualTo(25);
     IntStream.range(0, flattenedRecords.size())
-        .forEach(i -> assertThat(flattenedRecords.get(i).seqNum()).isEqualTo(i));
+        .forEach(i -> assertThat(flattenedRecords.get(i).seqNum).isEqualTo(i));
   }
 }


### PR DESCRIPTION
Not thrilled about this, but AWS's managed flink runtime requires 11.

Removes use of records, sealed classes, `toList`, switch expressions... 🙃 