### PR TITLE
chore: new proto changes; read session heartbeat

### DIFF
--- a/app/src/main/java/org/example/app/ManagedReadSessionDemo.java
+++ b/app/src/main/java/org/example/app/ManagedReadSessionDemo.java
@@ -10,7 +10,6 @@ import s2.client.StreamClient;
 import s2.config.Config;
 import s2.config.Endpoints;
 import s2.types.Batch;
-import s2.types.ReadLimit;
 import s2.types.ReadSessionRequest;
 
 public class ManagedReadSessionDemo {
@@ -50,7 +49,7 @@ public class ManagedReadSessionDemo {
 
       try (final var managedSession =
           streamClient.managedReadSession(
-              ReadSessionRequest.newBuilder().withReadLimit(ReadLimit.count(100_000)).build(),
+              ReadSessionRequest.newBuilder().withHeartbeats(true).build(),
               1024 * 1024 * 1024 * 5)) {
 
         AtomicLong receivedBytes = new AtomicLong();

--- a/app/src/main/resources/logback.xml
+++ b/app/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
     </encoder>
   </appender>
 
-  <logger additivity="false" level="info" name="s2">
+  <logger additivity="false" level="trace" name="s2">
     <appender-ref ref="console"/>
   </logger>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.14-SNAPSHOT
+version=0.0.14

--- a/s2-sdk/src/main/java/s2/types/BasinInfo.java
+++ b/s2-sdk/src/main/java/s2/types/BasinInfo.java
@@ -2,18 +2,29 @@ package s2.types;
 
 public class BasinInfo {
   public final String name;
-  public final String scope;
-  public final String cell;
+  public final BasinScope basinScope;
   public final BasinState basinState;
 
-  BasinInfo(String name, String scope, String cell, BasinState basinState) {
+  BasinInfo(String name, BasinScope basinScope, BasinState basinState) {
     this.name = name;
-    this.scope = scope;
-    this.cell = cell;
+    this.basinScope = basinScope;
     this.basinState = basinState;
   }
 
   public static BasinInfo fromProto(s2.v1alpha.BasinInfo basinInfo) {
+    BasinScope scope;
+    switch (basinInfo.getScope()) {
+      case BASIN_SCOPE_UNSPECIFIED:
+        scope = BasinScope.UNSPECIFIED;
+        break;
+      case BASIN_SCOPE_AWS_US_EAST_1:
+        scope = BasinScope.AWS_US_EAST_1;
+        break;
+      default:
+        scope = BasinScope.UNKNOWN;
+        break;
+    }
+
     BasinState state;
     switch (basinInfo.getState()) {
       case BASIN_STATE_UNSPECIFIED:
@@ -33,6 +44,6 @@ public class BasinInfo {
         break;
     }
 
-    return new BasinInfo(basinInfo.getName(), basinInfo.getScope(), basinInfo.getCell(), state);
+    return new BasinInfo(basinInfo.getName(), scope, state);
   }
 }

--- a/s2-sdk/src/main/java/s2/types/BasinScope.java
+++ b/s2-sdk/src/main/java/s2/types/BasinScope.java
@@ -1,0 +1,7 @@
+package s2.types;
+
+public enum BasinScope {
+  UNSPECIFIED,
+  AWS_US_EAST_1,
+  UNKNOWN
+}

--- a/s2-sdk/src/main/java/s2/types/ReadSessionRequest.java
+++ b/s2-sdk/src/main/java/s2/types/ReadSessionRequest.java
@@ -6,10 +6,12 @@ public class ReadSessionRequest {
 
   public final long startSeqNum;
   public final ReadLimit readLimit;
+  public final boolean heartbeats;
 
-  protected ReadSessionRequest(long startSeqNum, ReadLimit readLimit) {
+  protected ReadSessionRequest(long startSeqNum, ReadLimit readLimit, boolean heartbeats) {
     this.startSeqNum = startSeqNum;
     this.readLimit = readLimit;
+    this.heartbeats = heartbeats;
   }
 
   public static ReadSessionRequestBuilder newBuilder() {
@@ -18,14 +20,7 @@ public class ReadSessionRequest {
 
   public ReadSessionRequest update(long newStartSeqNum, long consumedRecords, long consumedBytes) {
     return new ReadSessionRequest(
-        newStartSeqNum, readLimit.remaining(consumedRecords, consumedBytes));
-  }
-
-  public s2.v1alpha.ReadSessionRequest toProto() {
-    return s2.v1alpha.ReadSessionRequest.newBuilder()
-        .setStartSeqNum(startSeqNum)
-        .setLimit(readLimit.toProto())
-        .build();
+        newStartSeqNum, readLimit.remaining(consumedRecords, consumedBytes), heartbeats);
   }
 
   public s2.v1alpha.ReadSessionRequest toProto(String streamName) {
@@ -33,12 +28,14 @@ public class ReadSessionRequest {
         .setStream(streamName)
         .setStartSeqNum(startSeqNum)
         .setLimit(readLimit.toProto())
+        .setHeartbeats(heartbeats)
         .build();
   }
 
   public static class ReadSessionRequestBuilder {
     private Optional<Long> startSeqNum = Optional.empty();
     private Optional<ReadLimit> readLimit = Optional.empty();
+    private boolean heartbeats = false;
 
     public ReadSessionRequestBuilder withStartSeqNum(long startSeqNum) {
       this.startSeqNum = Optional.of(startSeqNum);
@@ -50,9 +47,14 @@ public class ReadSessionRequest {
       return this;
     }
 
+    public ReadSessionRequestBuilder withHeartbeats(boolean heartbeats) {
+      this.heartbeats = heartbeats;
+      return this;
+    }
+
     public ReadSessionRequest build() {
       return new ReadSessionRequest(
-          this.startSeqNum.orElse(0L), this.readLimit.orElse(ReadLimit.NONE));
+          this.startSeqNum.orElse(0L), this.readLimit.orElse(ReadLimit.NONE), this.heartbeats);
     }
   }
 }


### PR DESCRIPTION
Closes https://github.com/s2-streamstore/s2-sdk-java/issues/13
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces heartbeat support in `ReadSession`, updates `BasinInfo` to use `BasinScope` enum, and adjusts logging and version.
> 
>   - **ReadSession Heartbeat**:
>     - Added heartbeat support in `ReadSession` with `livenessDaemon()` and `scheduleLivenessCheck()` methods.
>     - `ReadSessionRequest` updated to include `heartbeats` boolean.
>     - Heartbeat logging added in `readSessionInner()`.
>   - **BasinInfo and BasinScope**:
>     - `BasinInfo` now uses `BasinScope` enum instead of `String` for scope.
>     - New `BasinScope` enum created with values `UNSPECIFIED`, `AWS_US_EAST_1`, and `UNKNOWN`.
>   - **Logging and Version**:
>     - Changed logger level to `trace` for `s2` in `logback.xml`.
>     - Updated version to `0.0.14` in `gradle.properties`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fs2-sdk-java&utm_source=github&utm_medium=referral)<sup> for be936972f739ce627772067a61d03a12156aeb6f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->