### PR TITLE
chore: s2 API updates, version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For the demos discussed below, it will be helpful to create a new basin and stre
 Start by setting some environment variables in your shell.
 
 ```bash
-export S2_AUTH_TOKEN="MY-SECRET"
+export S2_ACCESS_TOKEN="MY-SECRET"
 export S2_BASIN="my-demo-java"
 export S2_STREAM="test/1"
 ```

--- a/app/src/main/java/org/example/app/AccountDemo.java
+++ b/app/src/main/java/org/example/app/AccountDemo.java
@@ -8,10 +8,13 @@ import s2.client.Client;
 import s2.config.Config;
 import s2.config.Endpoints;
 import s2.types.Age;
+import s2.types.BasinConfig;
 import s2.types.CreateBasinRequest;
 import s2.types.ListBasinsRequest;
 import s2.types.StorageClass;
 import s2.types.StreamConfig;
+import s2.types.Timestamping;
+import s2.types.TimestampingMode;
 
 public class AccountDemo {
 
@@ -19,7 +22,7 @@ public class AccountDemo {
 
   public static void main(String[] args) throws Exception {
     var config =
-        Config.newBuilder(System.getenv("S2_AUTH_TOKEN"))
+        Config.newBuilder(System.getenv("S2_ACCESS_TOKEN"))
             .withEndpoints(Endpoints.fromEnvironment())
             .build();
 
@@ -33,11 +36,16 @@ public class AccountDemo {
               .createBasin(
                   CreateBasinRequest.newBuilder()
                       .withBasin(UUID.randomUUID().toString())
-                      .withDefaultStreamConfig(
-                          StreamConfig.newBuilder()
-                              .withRetentionPolicy(new Age(Duration.ofDays(7)))
-                              .withStorageClass(StorageClass.STANDARD)
-                              .build())
+                      .withBasinConfig(
+                          new BasinConfig(
+                              StreamConfig.newBuilder()
+                                  .withRetentionPolicy(new Age(Duration.ofDays(7)))
+                                  .withTimestamping(
+                                      new Timestamping(TimestampingMode.CLIENT_REQUIRE, true))
+                                  .withStorageClass(StorageClass.STANDARD)
+                                  .build(),
+                              false,
+                              false))
                       .build())
               .get();
       logger.info("newBasin={}", newBasin);

--- a/app/src/main/java/org/example/app/BasinDemo.java
+++ b/app/src/main/java/org/example/app/BasinDemo.java
@@ -15,7 +15,7 @@ public class BasinDemo {
 
   public static void main(String[] args) throws Exception {
     final var config =
-        Config.newBuilder(System.getenv("S2_AUTH_TOKEN"))
+        Config.newBuilder(System.getenv("S2_ACCESS_TOKEN"))
             .withEndpoints(Endpoints.fromEnvironment())
             .build();
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.15-SNAPSHOT
+version=0.0.15

--- a/s2-sdk/src/main/java/s2/client/BaseClient.java
+++ b/s2-sdk/src/main/java/s2/client/BaseClient.java
@@ -55,6 +55,7 @@ public abstract class BaseClient implements AutoCloseable {
     switch (status.getCode()) {
       case UNKNOWN:
       case DEADLINE_EXCEEDED:
+      case RESOURCE_EXHAUSTED:
       case UNAVAILABLE:
         return true;
       default:

--- a/s2-sdk/src/main/java/s2/client/Client.java
+++ b/s2-sdk/src/main/java/s2/client/Client.java
@@ -20,7 +20,6 @@ import s2.types.BasinInfo;
 import s2.types.CreateBasinRequest;
 import s2.types.Paginated;
 import s2.types.ReconfigureBasinRequest;
-import s2.types.StreamConfig;
 import s2.v1alpha.AccountServiceGrpc;
 import s2.v1alpha.DeleteBasinRequest;
 import s2.v1alpha.GetBasinConfigRequest;
@@ -125,9 +124,7 @@ public class Client extends BaseClient {
                 withStaticRetries(
                     config.maxRetries,
                     () -> this.futureStub.reconfigureBasin(reconfigure.toProto())),
-                resp ->
-                    new BasinConfig(
-                        StreamConfig.fromProto(resp.getConfig().getDefaultStreamConfig())),
+                resp -> BasinConfig.fromProto(resp.getConfig()),
                 executor));
   }
 
@@ -146,9 +143,7 @@ public class Client extends BaseClient {
                     () ->
                         this.futureStub.getBasinConfig(
                             GetBasinConfigRequest.newBuilder().setBasin(basin).build())),
-                resp ->
-                    new BasinConfig(
-                        StreamConfig.fromProto(resp.getConfig().getDefaultStreamConfig())),
+                resp -> BasinConfig.fromProto(resp.getConfig()),
                 executor));
   }
 

--- a/s2-sdk/src/main/java/s2/client/ManagedAppendSession.java
+++ b/s2-sdk/src/main/java/s2/client/ManagedAppendSession.java
@@ -57,6 +57,10 @@ public class ManagedAppendSession implements AutoCloseable {
     this.remainingAttempts = new AtomicInteger(this.client.config.maxRetries);
   }
 
+  public Integer remainingBufferCapacityBytes() {
+    return this.inflightBytes.availablePermits();
+  }
+
   private ListenableFuture<Void> retryingDaemon() {
     return Futures.catchingAsync(
         executor.submit(this::daemon),
@@ -370,6 +374,8 @@ public class ManagedAppendSession implements AutoCloseable {
     return daemon;
   }
 
+  interface Notification {}
+
   static class InflightRecord {
     final AppendInput input;
     final long entryNanos;
@@ -391,8 +397,6 @@ public class ManagedAppendSession implements AutoCloseable {
       return new InflightRecord(input, System.nanoTime(), SettableFuture.create(), meteredBytes);
     }
   }
-
-  interface Notification {}
 
   class Ack implements Notification {
     final AppendOutput output;

--- a/s2-sdk/src/main/java/s2/client/ManagedReadSession.java
+++ b/s2-sdk/src/main/java/s2/client/ManagedReadSession.java
@@ -101,7 +101,6 @@ public class ManagedReadSession implements AutoCloseable {
   }
 
   interface ReadItem {}
-  ;
 
   static class DataItem implements ReadItem {
     final ReadOutput readOutput;

--- a/s2-sdk/src/main/java/s2/types/AppendInput.java
+++ b/s2-sdk/src/main/java/s2/types/AppendInput.java
@@ -1,6 +1,5 @@
 package s2.types;
 
-import com.google.protobuf.ByteString;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
@@ -8,10 +7,10 @@ import java.util.Optional;
 public class AppendInput implements MeteredBytes, Serializable {
   public final List<AppendRecord> records;
   public final Optional<Long> matchSeqNum;
-  public final Optional<ByteString> fencingToken;
+  public final Optional<String> fencingToken;
 
   private AppendInput(
-      List<AppendRecord> records, Optional<Long> matchSeqNum, Optional<ByteString> fencingToken) {
+      List<AppendRecord> records, Optional<Long> matchSeqNum, Optional<String> fencingToken) {
     this.records = records;
     this.matchSeqNum = matchSeqNum;
     this.fencingToken = fencingToken;
@@ -38,7 +37,7 @@ public class AppendInput implements MeteredBytes, Serializable {
   public static class AppendInputBuilder {
     private List<AppendRecord> records = List.of();
     private Optional<Long> matchSeqNum = Optional.empty();
-    private Optional<ByteString> fencingToken = Optional.empty();
+    private Optional<String> fencingToken = Optional.empty();
 
     public AppendInputBuilder withRecords(List<AppendRecord> records) {
       this.records = records;
@@ -50,7 +49,7 @@ public class AppendInput implements MeteredBytes, Serializable {
       return this;
     }
 
-    public AppendInputBuilder withFencingToken(ByteString fencingToken) {
+    public AppendInputBuilder withFencingToken(String fencingToken) {
       this.fencingToken = Optional.of(fencingToken);
       return this;
     }
@@ -64,8 +63,8 @@ public class AppendInput implements MeteredBytes, Serializable {
           });
       fencingToken.ifPresent(
           token -> {
-            if (token.size() > 16) {
-              throw new IllegalArgumentException("fencingToken must be less than 16 bytes");
+            if (token.length() > 36) {
+              throw new IllegalArgumentException("fencingToken must be 36 or fewer UTF-8 bytes");
             }
           });
       var provisional = new AppendInput(records, matchSeqNum, fencingToken);

--- a/s2-sdk/src/main/java/s2/types/BasinConfig.java
+++ b/s2-sdk/src/main/java/s2/types/BasinConfig.java
@@ -2,14 +2,28 @@ package s2.types;
 
 public class BasinConfig {
   public final StreamConfig defaultStreamConfig;
+  public final boolean createStreamOnAppend;
+  public final boolean createStreamOnRead;
 
-  public BasinConfig(StreamConfig defaultStreamConfig) {
+  public BasinConfig(
+      StreamConfig defaultStreamConfig, boolean createStreamOnAppend, boolean createStreamOnRead) {
     this.defaultStreamConfig = defaultStreamConfig;
+    this.createStreamOnAppend = createStreamOnAppend;
+    this.createStreamOnRead = createStreamOnRead;
+  }
+
+  public static BasinConfig fromProto(s2.v1alpha.BasinConfig basinConfig) {
+    return new BasinConfig(
+        StreamConfig.fromProto(basinConfig.getDefaultStreamConfig()),
+        basinConfig.getCreateStreamOnAppend(),
+        basinConfig.getCreateStreamOnRead());
   }
 
   public s2.v1alpha.BasinConfig toProto() {
     return s2.v1alpha.BasinConfig.newBuilder()
         .setDefaultStreamConfig(defaultStreamConfig.toProto())
+        .setCreateStreamOnAppend(createStreamOnAppend)
+        .setCreateStreamOnRead(createStreamOnRead)
         .build();
   }
 }

--- a/s2-sdk/src/main/java/s2/types/Batch.java
+++ b/s2-sdk/src/main/java/s2/types/Batch.java
@@ -1,5 +1,6 @@
 package s2.types;
 
+import java.time.Instant;
 import java.util.Optional;
 
 public final class Batch implements ReadOutput, MeteredBytes {
@@ -18,6 +19,19 @@ public final class Batch implements ReadOutput, MeteredBytes {
     if (!this.sequencedRecordBatch.records.isEmpty()) {
       return Optional.of(
           this.sequencedRecordBatch.records.get(sequencedRecordBatch.records.size() - 1).seqNum);
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  public Optional<Instant> firstTimestamp() {
+    return this.sequencedRecordBatch.records.stream().findFirst().map(sr -> sr.timestamp);
+  }
+
+  public Optional<Instant> lastTimestamp() {
+    if (!this.sequencedRecordBatch.records.isEmpty()) {
+      return Optional.of(
+          this.sequencedRecordBatch.records.get(sequencedRecordBatch.records.size() - 1).timestamp);
     } else {
       return Optional.empty();
     }

--- a/s2-sdk/src/main/java/s2/types/CreateBasinRequest.java
+++ b/s2-sdk/src/main/java/s2/types/CreateBasinRequest.java
@@ -56,8 +56,8 @@ public class CreateBasinRequest {
       return this;
     }
 
-    public CreateBasinRequestBuilder withDefaultStreamConfig(StreamConfig config) {
-      this.config = Optional.of(new BasinConfig(config));
+    public CreateBasinRequestBuilder withBasinConfig(BasinConfig config) {
+      this.config = Optional.of(config);
       return this;
     }
 
@@ -75,7 +75,7 @@ public class CreateBasinRequest {
       this.basin.ifPresent(BasinUtils::validateBasinName);
       return new CreateBasinRequest(
           this.basin,
-          this.config.orElse(new BasinConfig(StreamConfig.newBuilder().build())),
+          this.config.orElse(new BasinConfig(StreamConfig.newBuilder().build(), false, false)),
           this.assignment);
     }
   }

--- a/s2-sdk/src/main/java/s2/types/Header.java
+++ b/s2-sdk/src/main/java/s2/types/Header.java
@@ -11,11 +11,11 @@ public class Header {
     this.value = value;
   }
 
-  public s2.v1alpha.Header toProto() {
-    return s2.v1alpha.Header.newBuilder().setName(name).setValue(value).build();
-  }
-
   public static Header fromProto(s2.v1alpha.Header protoHeader) {
     return new Header(protoHeader.getName(), protoHeader.getValue());
+  }
+
+  public s2.v1alpha.Header toProto() {
+    return s2.v1alpha.Header.newBuilder().setName(name).setValue(value).build();
   }
 }

--- a/s2-sdk/src/main/java/s2/types/ReadOutput.java
+++ b/s2-sdk/src/main/java/s2/types/ReadOutput.java
@@ -5,8 +5,6 @@ public interface ReadOutput {
     switch (readOutput.getOutputCase()) {
       case BATCH:
         return new Batch(SequencedRecordBatch.fromProto(readOutput.getBatch()));
-      case FIRST_SEQ_NUM:
-        return new FirstSeqNum(readOutput.getFirstSeqNum());
       case NEXT_SEQ_NUM:
         return new NextSeqNum(readOutput.getNextSeqNum());
     }

--- a/s2-sdk/src/main/java/s2/types/ReadSessionRequest.java
+++ b/s2-sdk/src/main/java/s2/types/ReadSessionRequest.java
@@ -4,12 +4,12 @@ import java.util.Optional;
 
 public class ReadSessionRequest {
 
-  public final long startSeqNum;
+  public final Start start;
   public final ReadLimit readLimit;
   public final boolean heartbeats;
 
-  protected ReadSessionRequest(long startSeqNum, ReadLimit readLimit, boolean heartbeats) {
-    this.startSeqNum = startSeqNum;
+  protected ReadSessionRequest(Start start, ReadLimit readLimit, boolean heartbeats) {
+    this.start = start;
     this.readLimit = readLimit;
     this.heartbeats = heartbeats;
   }
@@ -18,27 +18,38 @@ public class ReadSessionRequest {
     return new ReadSessionRequestBuilder();
   }
 
-  public ReadSessionRequest update(long newStartSeqNum, long consumedRecords, long consumedBytes) {
+  public ReadSessionRequest update(Start start, long consumedRecords, long consumedBytes) {
     return new ReadSessionRequest(
-        newStartSeqNum, readLimit.remaining(consumedRecords, consumedBytes), heartbeats);
+        start, readLimit.remaining(consumedRecords, consumedBytes), heartbeats);
   }
 
   public s2.v1alpha.ReadSessionRequest toProto(String streamName) {
-    return s2.v1alpha.ReadSessionRequest.newBuilder()
-        .setStream(streamName)
-        .setStartSeqNum(startSeqNum)
-        .setLimit(readLimit.toProto())
-        .setHeartbeats(heartbeats)
-        .build();
+    s2.v1alpha.ReadSessionRequest.Builder builder =
+        s2.v1alpha.ReadSessionRequest.newBuilder()
+            .setStream(streamName)
+            .setLimit(readLimit.toProto())
+            .setHeartbeats(heartbeats);
+
+    if (start instanceof Start.SeqNum) {
+      builder.setSeqNum(((Start.SeqNum) start).value);
+    } else if (start instanceof Start.Timestamp) {
+      builder.setTimestamp(((Start.Timestamp) start).value);
+    } else if (start instanceof Start.TailOffset) {
+      builder.setTailOffset(((Start.TailOffset) start).value);
+    } else {
+      throw new IllegalStateException("Unknown Start type: " + start.getClass().getName());
+    }
+
+    return builder.build();
   }
 
   public static class ReadSessionRequestBuilder {
-    private Optional<Long> startSeqNum = Optional.empty();
+    private Optional<Start> start = Optional.empty();
     private Optional<ReadLimit> readLimit = Optional.empty();
     private boolean heartbeats = false;
 
-    public ReadSessionRequestBuilder withStartSeqNum(long startSeqNum) {
-      this.startSeqNum = Optional.of(startSeqNum);
+    public ReadSessionRequestBuilder withStart(Start start) {
+      this.start = Optional.of(start);
       return this;
     }
 
@@ -54,7 +65,9 @@ public class ReadSessionRequest {
 
     public ReadSessionRequest build() {
       return new ReadSessionRequest(
-          this.startSeqNum.orElse(0L), this.readLimit.orElse(ReadLimit.NONE), this.heartbeats);
+          this.start.orElseGet(() -> Start.seqNum(0L)),
+          this.readLimit.orElse(ReadLimit.NONE),
+          this.heartbeats);
     }
   }
 }

--- a/s2-sdk/src/main/java/s2/types/SequencedRecord.java
+++ b/s2-sdk/src/main/java/s2/types/SequencedRecord.java
@@ -1,6 +1,7 @@
 package s2.types;
 
 import com.google.protobuf.ByteString;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -8,19 +9,13 @@ public class SequencedRecord implements MeteredBytes {
   public final long seqNum;
   public final List<Header> headers;
   public final ByteString body;
+  public final Instant timestamp;
 
-  SequencedRecord(long seqNum, List<Header> headers, ByteString body) {
+  SequencedRecord(long seqNum, List<Header> headers, ByteString body, Instant timestamp) {
     this.seqNum = seqNum;
     this.headers = headers;
     this.body = body;
-  }
-
-  @Override
-  public long meteredBytes() {
-    return 8
-        + (2L * this.headers.size())
-        + this.headers.stream().map(h -> h.name.size() + h.value.size()).reduce(0, Integer::sum)
-        + this.body.size();
+    this.timestamp = timestamp;
   }
 
   public static SequencedRecord fromProto(s2.v1alpha.SequencedRecord sequencedRecord) {
@@ -29,6 +24,15 @@ public class SequencedRecord implements MeteredBytes {
         sequencedRecord.getHeadersList().stream()
             .map(Header::fromProto)
             .collect(Collectors.toList()),
-        sequencedRecord.getBody());
+        sequencedRecord.getBody(),
+        Instant.ofEpochMilli(sequencedRecord.getTimestamp()));
+  }
+
+  @Override
+  public long meteredBytes() {
+    return 8
+        + (2L * this.headers.size())
+        + this.headers.stream().map(h -> h.name.size() + h.value.size()).reduce(0, Integer::sum)
+        + this.body.size();
   }
 }

--- a/s2-sdk/src/main/java/s2/types/Start.java
+++ b/s2-sdk/src/main/java/s2/types/Start.java
@@ -1,0 +1,45 @@
+package s2.types;
+
+import java.time.Instant;
+
+public abstract class Start {
+  public static SeqNum seqNum(long seqNum) {
+    return new SeqNum(seqNum);
+  }
+
+  public static Timestamp timestamp(Instant instant) {
+    return new Timestamp(instant.toEpochMilli());
+  }
+
+  public static TailOffset tailOffset(long tailOffset) {
+    return new TailOffset(tailOffset);
+  }
+
+  public static final class SeqNum extends Start {
+    public final long value;
+
+    private SeqNum(long value) {
+      this.value = value;
+    }
+  }
+
+  public static final class Timestamp extends Start {
+    public final long value;
+
+    private Timestamp(long value) {
+      this.value = value;
+    }
+
+    public Instant toInstant() {
+      return Instant.ofEpochMilli(value);
+    }
+  }
+
+  public static final class TailOffset extends Start {
+    public final long value;
+
+    private TailOffset(long value) {
+      this.value = value;
+    }
+  }
+}

--- a/s2-sdk/src/main/java/s2/types/StreamConfig.java
+++ b/s2-sdk/src/main/java/s2/types/StreamConfig.java
@@ -8,10 +8,15 @@ public class StreamConfig {
 
   public final StorageClass storageClass;
   public final Optional<RetentionPolicy> retentionPolicy;
+  public final Optional<Timestamping> timestamping;
 
-  StreamConfig(StorageClass storageClass, Optional<RetentionPolicy> retentionPolicy) {
+  StreamConfig(
+      StorageClass storageClass,
+      Optional<RetentionPolicy> retentionPolicy,
+      Optional<Timestamping> timestamping) {
     this.storageClass = storageClass;
     this.retentionPolicy = retentionPolicy;
+    this.timestamping = timestamping;
   }
 
   public static StreamConfig fromProto(s2.v1alpha.StreamConfig proto) {
@@ -36,7 +41,13 @@ public class StreamConfig {
     if (proto.getRetentionPolicyCase() == RetentionPolicyCase.AGE) {
       retentionPolicy = Optional.of(new Age(Duration.ofSeconds(proto.getAge())));
     }
-    return new StreamConfig(storageClass, retentionPolicy);
+
+    Optional<Timestamping> timestamping = Optional.empty();
+    if (proto.hasTimestamping()) {
+      timestamping = Optional.of(Timestamping.fromProto(proto.getTimestamping()));
+    }
+
+    return new StreamConfig(storageClass, retentionPolicy, timestamping);
   }
 
   public static StreamConfigBuilder newBuilder() {
@@ -44,12 +55,43 @@ public class StreamConfig {
   }
 
   public s2.v1alpha.StreamConfig toProto() {
-    return s2.v1alpha.StreamConfig.newBuilder().build();
+    var builder = s2.v1alpha.StreamConfig.newBuilder();
+    final s2.v1alpha.StorageClass storageClass;
+    switch (this.storageClass) {
+      case UNKNOWN:
+        throw new IllegalArgumentException("Unknown storage class: " + this.storageClass);
+      case STANDARD:
+        storageClass = s2.v1alpha.StorageClass.STORAGE_CLASS_STANDARD;
+        break;
+      case EXPRESS:
+        storageClass = s2.v1alpha.StorageClass.STORAGE_CLASS_EXPRESS;
+        break;
+      case UNSPECIFIED:
+      default:
+        storageClass = s2.v1alpha.StorageClass.STORAGE_CLASS_UNSPECIFIED;
+        break;
+    }
+
+    builder.setStorageClass(storageClass);
+
+    if (retentionPolicy.isPresent()) {
+      RetentionPolicy retentionPolicy = this.retentionPolicy.get();
+      if (retentionPolicy instanceof Age) {
+        builder.setAge(((Age) retentionPolicy).age.getSeconds());
+      } else {
+        throw new IllegalArgumentException("Invalid retention policy: " + retentionPolicy);
+      }
+    }
+
+    this.timestamping.ifPresent(ts -> builder.setTimestamping(ts.toProto()));
+
+    return builder.build();
   }
 
   public static class StreamConfigBuilder {
     private Optional<StorageClass> storageClass = Optional.empty();
     private Optional<RetentionPolicy> retentionPolicy = Optional.empty();
+    private Optional<Timestamping> timestamping = Optional.empty();
 
     public StreamConfigBuilder withStorageClass(StorageClass storageClass) {
       this.storageClass = Optional.of(storageClass);
@@ -61,8 +103,14 @@ public class StreamConfig {
       return this;
     }
 
+    public StreamConfigBuilder withTimestamping(Timestamping timestamping) {
+      this.timestamping = Optional.of(timestamping);
+      return this;
+    }
+
     public StreamConfig build() {
-      return new StreamConfig(this.storageClass.orElse(StorageClass.EXPRESS), this.retentionPolicy);
+      return new StreamConfig(
+          this.storageClass.orElse(StorageClass.EXPRESS), this.retentionPolicy, this.timestamping);
     }
   }
 }

--- a/s2-sdk/src/main/java/s2/types/Timestamping.java
+++ b/s2-sdk/src/main/java/s2/types/Timestamping.java
@@ -1,0 +1,68 @@
+package s2.types;
+
+import s2.v1alpha.StreamConfig;
+
+public class Timestamping {
+  public final TimestampingMode mode;
+  public final boolean uncapped;
+
+  /**
+   * Instantiates a new Timestamping.
+   *
+   * @param mode selected timestamping behavior
+   * @param uncapped if client-specified timestamps should be allowed to exceed the arrival time
+   */
+  public Timestamping(TimestampingMode mode, boolean uncapped) {
+    this.mode = mode;
+    this.uncapped = uncapped;
+  }
+
+  public static Timestamping fromProto(StreamConfig.Timestamping proto) {
+    final TimestampingMode mode;
+    switch (proto.getMode()) {
+      case TIMESTAMPING_MODE_UNSPECIFIED:
+        mode = TimestampingMode.UNSPECIFIED;
+        break;
+      case TIMESTAMPING_MODE_CLIENT_PREFER:
+        mode = TimestampingMode.CLIENT_PREFER;
+        break;
+      case TIMESTAMPING_MODE_CLIENT_REQUIRE:
+        mode = TimestampingMode.CLIENT_REQUIRE;
+        break;
+      case TIMESTAMPING_MODE_ARRIVAL:
+        mode = TimestampingMode.ARRIVAL;
+        break;
+      case UNRECOGNIZED:
+      default:
+        mode = TimestampingMode.UNKNOWN;
+        break;
+    }
+
+    return new Timestamping(mode, proto.getUncapped());
+  }
+
+  public StreamConfig.Timestamping toProto() {
+    final s2.v1alpha.TimestampingMode timestampingMode;
+    switch (mode) {
+      case UNSPECIFIED:
+        timestampingMode = s2.v1alpha.TimestampingMode.TIMESTAMPING_MODE_UNSPECIFIED;
+        break;
+      case CLIENT_PREFER:
+        timestampingMode = s2.v1alpha.TimestampingMode.TIMESTAMPING_MODE_CLIENT_PREFER;
+        break;
+      case CLIENT_REQUIRE:
+        timestampingMode = s2.v1alpha.TimestampingMode.TIMESTAMPING_MODE_CLIENT_REQUIRE;
+        break;
+      case ARRIVAL:
+        timestampingMode = s2.v1alpha.TimestampingMode.TIMESTAMPING_MODE_ARRIVAL;
+        break;
+      default:
+        throw new IllegalArgumentException("Unexpected value for timestamping mode: " + mode);
+    }
+
+    return StreamConfig.Timestamping.newBuilder()
+        .setMode(timestampingMode)
+        .setUncapped(uncapped)
+        .build();
+  }
+}

--- a/s2-sdk/src/main/java/s2/types/TimestampingMode.java
+++ b/s2-sdk/src/main/java/s2/types/TimestampingMode.java
@@ -1,0 +1,12 @@
+package s2.types;
+
+public enum TimestampingMode {
+  UNKNOWN,
+  UNSPECIFIED,
+  /// Prefer client-specified timestamp if present otherwise use arrival time.
+  CLIENT_PREFER,
+  /// Require a client-specified timestamp and reject the append if it is missing.
+  CLIENT_REQUIRE,
+  /// Use the arrival time and ignore any client-specified timestamp.
+  ARRIVAL
+}

--- a/s2-sdk/src/test/java/s2/client/ReadSessionTest.java
+++ b/s2-sdk/src/test/java/s2/client/ReadSessionTest.java
@@ -20,6 +20,7 @@ import s2.types.Batch;
 import s2.types.ReadLimit;
 import s2.types.ReadOutput;
 import s2.types.ReadSessionRequest;
+import s2.types.Start;
 import s2.v1alpha.StreamService.MockReadSessionStreamService;
 
 public class ReadSessionTest {
@@ -61,7 +62,7 @@ public class ReadSessionTest {
   public void testReadSession() throws Exception {
     ReadSessionRequest request =
         ReadSessionRequest.newBuilder()
-            .withStartSeqNum(0)
+            .withStart(Start.seqNum(0))
             .withReadLimit(ReadLimit.count(25))
             .build();
 


### PR DESCRIPTION
Adds functionality from recent s2 API updates:
- Timestamp support
- `ReadLimit` and `Start` types
- Fencing token as utf-8 string, not bytes
- Stream create_on_append / create_on_read config 

Miscellaneous tweaks
- handle `RESOURCE_EXHAUSTED` grpc status
- backpressure in managed append session demo